### PR TITLE
Updated SSHException to meetup with conform python 3.x

### DIFF
--- a/CVE-2018-10933.py
+++ b/CVE-2018-10933.py
@@ -29,7 +29,7 @@ def main(hostname="127.0.0.1", port=22):
         cmd_channel = transport.open_session()
         cmd_channel.invoke_shell()
     except SSHException as e:
-        print(f'SSH Exception: {e}', file=sys.stdout)
+        print('SSH Exception: {}'.format(e))
         return 1
 
 


### PR DESCRIPTION
Since you are using Python 3.x., you should actually be using the newer str.format method. Though % and , formatting is not officially deprecated (yet), it is discouraged in favor of str.format and will most likely be removed from the language in a coming version (Python 4 maybe?).

Tested with:
```
python --version
Python 2.7.13
```

And:
```
python3 --version
Python 3.5.3
```

And:
```
python3.6 --version
Python 3.6.6
```

Fixes:
https://github.com/SoledaD208/CVE-2018-10933/issues/7